### PR TITLE
Remove handler (de)serialization

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,3 +87,10 @@ This is an error normally caused when a function can't find the DynamoDB table.
 Generally this is caused when the `TABLE_NAME` variable is incorrectly set -
 check [`dev/envVars.json`](./dev/envVars.json) to ensure your function is
 receiving it correctly.
+
+#### Missing credentials in config, if using AWS_CONFIG_FILE, set AWS_SDK_LOAD_CONFIG=1
+
+The AWS SDK is unable to authenticate you. This is normally caused by a similar
+error as above (`TABLE_NAME` incorrectly set). Add `AWS_ACCESS_KEY_ID` and
+`AWS_SECRET_ACCESS_KEY` and `AWS_REGION` to `dev/envVars.json` for your
+function.

--- a/dev/scripts/envVars.json
+++ b/dev/scripts/envVars.json
@@ -1,10 +1,26 @@
 {
+    "RootWelcome": {
+        "TABLE_NAME": "Table0",
+        "DYNAMO_HOST": "http://dynamodb:8000",
+        "AWS_ACCESS_KEY_ID": "FakeID",
+        "AWS_SECRET_ACCESS_KEY": "1234"
+    },
     "CallerCountFunction": {
         "TABLE_NAME": "Table0",
-        "DYNAMO_HOST": "http://dynamodb:8000"
+        "DYNAMO_HOST": "http://dynamodb:8000",
+        "AWS_ACCESS_KEY_ID": "FakeID",
+        "AWS_SECRET_ACCESS_KEY": "1234"
     },
-    "RecordMessageFunction_1": {
+    "RecordMessageWelcome": {
         "TABLE_NAME": "Table0",
-        "DYNAMO_HOST": "http://dynamodb:8000"
+        "DYNAMO_HOST": "http://dynamodb:8000",
+        "AWS_ACCESS_KEY_ID": "FakeID",
+        "AWS_SECRET_ACCESS_KEY": "1234"
+    },
+    "RecordMessageFunction": {
+        "TABLE_NAME": "Table0",
+        "DYNAMO_HOST": "http://dynamodb:8000",
+        "AWS_ACCESS_KEY_ID": "FakeID",
+        "AWS_SECRET_ACCESS_KEY": "1234"
     }
 }

--- a/src/handlers/callerCount/__snapshots__/index.test.ts.snap
+++ b/src/handlers/callerCount/__snapshots__/index.test.ts.snap
@@ -1,28 +1,10 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`Caller count should gracefully reject: Unable to identify caller 1`] = `
+exports[`Caller count should increment caller count 1`] = `
 <?xml version="1.0" encoding="UTF-8"?>
 <Response>
     <Say language="en-GB" voice="Polly.Amy">
-        An error occurred. Unable to identify caller
-    </Say>
-</Response>
-`;
-
-exports[`Caller count should gracefully reject: Unable to identify caller 2`] = `
-<?xml version="1.0" encoding="UTF-8"?>
-<Response>
-    <Say language="en-GB" voice="Polly.Amy">
-        An error occurred. Unable to identify caller
-    </Say>
-</Response>
-`;
-
-exports[`Caller count should gracefully reject: Unsupported language 1`] = `
-<?xml version="1.0" encoding="UTF-8"?>
-<Response>
-    <Say language="en-GB" voice="Polly.Amy">
-        An error occurred. Unsupported language
+        This is the 2nd time you've called.
     </Say>
 </Response>
 `;
@@ -33,8 +15,5 @@ exports[`Caller count should return well-formed XML 1`] = `
     <Say language="en-GB" voice="Polly.Amy">
         This is the 1st time you've called.
     </Say>
-    <Redirect method="GET">
-        ./record
-    </Redirect>
 </Response>
 `;

--- a/src/handlers/callerCount/index.test.ts
+++ b/src/handlers/callerCount/index.test.ts
@@ -1,44 +1,22 @@
-import { handler as orig } from '.';
+import * as orig from '.';
 import { mockHandlerFn } from '../../../dev/mockHandlerFn';
 
-const handler = mockHandlerFn(orig);
+const get = mockHandlerFn(orig.get);
+
 describe('Caller count', () => {
     it('should return well-formed XML', async () => {
-        const result = (await handler({
-            pathParameters: { lang: 'en-GB' },
-            queryStringParameters: { Caller: '+7777777' },
-        }));
-        expect(result).toMatchObject({
-            statusCode: 200,
-            headers: {
-                'Content-Type': 'text/xml',
-            },
-            body: expect.any(String),
+        const result = await get({
+            language: 'en-GB',
+            user: { id: '+77-caller-test' },
         });
-        expect(result.body).toMatchSnapshot();
+        expect(result.toString()).toMatchSnapshot();
     });
 
     it('should increment caller count', async () => {
-        const result = (await handler({
-            pathParameters: { lang: 'en-GB' },
-            queryStringParameters: { Caller: '+7777777' },
-        }));
-        expect(result).toMatchObject({
-            statusCode: 200,
-            body: expect.stringContaining(
-                "This is the 2nd time you've called."
-            ),
+        const result = await get({
+            language: 'en-GB',
+            user: { id: '+77-caller-test', count: 1 },
         });
-    });
-    test.each`
-        error                          | data
-        ${'Unable to identify caller'} | ${{}}
-        ${'Unable to identify caller'} | ${{ queryStringParameters: { Caller: '+1' } }}
-        ${'Unsupported language'}      | ${{ queryStringParameters: { Caller: '+7777777' } }}
-    `('should gracefully reject: $error', async ({ data }) => {
-        const result = (await handler(
-            data
-        ));
-        expect(result.body).toMatchSnapshot();
+        expect(result.toString()).toMatchSnapshot();
     });
 });

--- a/src/handlers/callerCount/index.ts
+++ b/src/handlers/callerCount/index.ts
@@ -1,42 +1,16 @@
-import { getItem, putItem } from '../../services/dynamodb';
+import { putItem } from '../../services/dynamodb';
 import { twiml } from 'twilio';
-import {
-    getVoiceParams,
-    __,
-    isSupportedLanguage,
-} from '../../services/strings';
+import { getVoiceParams, __ } from '../../services/strings';
 import { safeHandle } from '../../services/errors';
 
-export const handler = safeHandle(async (e) => {
-    // parse input
-    const name = e.queryStringParameters?.Caller;
-    if (name === undefined || name.length < 3) {
-        throw new Error('Unable to identify caller');
-    }
-    const language = e.pathParameters?.lang;
-    if (!isSupportedLanguage(language)) {
-        throw new Error('Unsupported language');
-    }
+export const get = safeHandle(async ({ language, user }) => {
+    user = await putItem({ ...user, count: (user.count || 0) + 1 });
 
-    // business logic - get/update DB
-    const getResult = await getItem(name);
-    const count = (getResult.count || 0) + 1;
-    await putItem(name, { count });
-
-    // prepare response
     const response = new twiml.VoiceResponse();
     response.say(
         getVoiceParams(language),
-        __('caller-count', { count }, language)
+        __('caller-count', { count: user.count }, language)
     );
-    response.redirect({ method: 'GET' }, `./record`);
 
-    // return answer
-    return {
-        statusCode: 200,
-        headers: {
-            'Content-Type': 'text/xml',
-        },
-        body: response.toString(),
-    };
+    return response;
 });

--- a/src/handlers/record/__snapshots__/index.test.ts.snap
+++ b/src/handlers/record/__snapshots__/index.test.ts.snap
@@ -1,41 +1,5 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`Recording should gracefully reject: Could not retrieve recording URL. 1`] = `
-<?xml version="1.0" encoding="UTF-8"?>
-<Response>
-    <Say language="en-GB" voice="Polly.Amy">
-        An error occurred. Could not retrieve recording URL.
-    </Say>
-</Response>
-`;
-
-exports[`Recording should gracefully reject: Unable to identify caller 1`] = `
-<?xml version="1.0" encoding="UTF-8"?>
-<Response>
-    <Say language="en-GB" voice="Polly.Amy">
-        An error occurred. Unable to identify caller
-    </Say>
-</Response>
-`;
-
-exports[`Recording should gracefully reject: Unable to identify caller 2`] = `
-<?xml version="1.0" encoding="UTF-8"?>
-<Response>
-    <Say language="en-GB" voice="Polly.Amy">
-        An error occurred. Unable to identify caller
-    </Say>
-</Response>
-`;
-
-exports[`Recording should gracefully reject: Unsupported language 1`] = `
-<?xml version="1.0" encoding="UTF-8"?>
-<Response>
-    <Say language="en-GB" voice="Polly.Amy">
-        An error occurred. Unsupported language
-    </Say>
-</Response>
-`;
-
 exports[`Recording should return well-formed XML to initial request 1`] = `
 <?xml version="1.0" encoding="UTF-8"?>
 <Response>
@@ -55,5 +19,8 @@ exports[`Recording should return well-formed XML to subsequent response 1`] = `
     <Play>
         https://my-file-server/voice.wav
     </Play>
+    <Redirect method="GET">
+        ./count
+    </Redirect>
 </Response>
 `;

--- a/src/handlers/record/index.ts
+++ b/src/handlers/record/index.ts
@@ -1,65 +1,42 @@
 import { putItem } from '../../services/dynamodb';
 import qs from 'querystring';
 import { twiml } from 'twilio';
-import {
-    getVoiceParams,
-    __,
-    isSupportedLanguage,
-} from '../../services/strings';
+import { getVoiceParams, __ } from '../../services/strings';
 import { safeHandle } from '../../services/errors';
 
-export const handler = safeHandle(async (e) => {
-    // parse input
-    const body = qs.parse(e.body || '');
-    const { Caller, RecordingUrl } = body;
-    const name = Caller || e.queryStringParameters?.Caller;
-    if (typeof name !== 'string' || name.length < 3) {
-        throw new Error('Unable to identify caller');
-    }
-    const language = e.pathParameters?.lang;
-    if (!isSupportedLanguage(language)) {
-        throw new Error('Unsupported language');
-    }
+export const get = safeHandle(async ({ language }) => {
+    const response = new twiml.VoiceResponse();
+    response.say(getVoiceParams(language), __('recording-request', language));
+    response.record({
+        // default action is to submit to same URL as current request
+        method: 'POST',
+        finishOnKey: '#',
+        playBeep: true,
+        trim: 'trim-silence',
+        maxLength: 5,
+    });
 
+    return response;
+});
+
+export const post = safeHandle(async ({ language, user, event }) => {
     const response = new twiml.VoiceResponse();
 
-    switch (e.httpMethod.toUpperCase()) {
-        case 'GET':
-        default:
-            response.say(
-                getVoiceParams(language),
-                __('recording-request', language)
-            );
-            response.record({
-                // default action is to submit to same URL as current request
-                method: 'POST',
-                finishOnKey: '#',
-                playBeep: true,
-                trim: 'trim-silence',
-                maxLength: 5,
-            });
+    const body = qs.parse(event.body || '');
+    const { RecordingUrl } = body;
 
-            break;
-        case 'POST':
-            // receiving RecordingUrl
-            if (typeof RecordingUrl !== 'string') {
-                throw new Error('Could not retrieve recording URL.');
-            }
-            await putItem(name, { recordingUrl: RecordingUrl });
-            response.say(
-                getVoiceParams(language),
-                __('recording-confirmation', language)
-            );
-            response.play(RecordingUrl);
-            break;
+    // receiving RecordingUrl
+    if (typeof RecordingUrl !== 'string') {
+        throw new Error('Could not retrieve recording URL.');
     }
+    await putItem({ ...user, recordingUrl: RecordingUrl });
+    response.say(
+        getVoiceParams(language),
+        __('recording-confirmation', language)
+    );
+    response.play(RecordingUrl);
 
-    // return answer
-    return {
-        statusCode: 200,
-        headers: {
-            'Content-Type': 'text/xml',
-        },
-        body: response.toString(),
-    };
+    response.redirect({ method: 'GET' }, `./count`);
+
+    return response;
 });

--- a/src/handlers/root/__snapshots__/index.test.ts.snap
+++ b/src/handlers/root/__snapshots__/index.test.ts.snap
@@ -1,14 +1,5 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`Greeting message should gracefully reject unknown languages 1`] = `
-<?xml version="1.0" encoding="UTF-8"?>
-<Response>
-    <Say language="en-GB" voice="Polly.Amy">
-        An error occurred. Unsupported language
-    </Say>
-</Response>
-`;
-
 exports[`Greeting message should return well-formed XML 1`] = `
 <?xml version="1.0" encoding="UTF-8"?>
 <Response>

--- a/src/handlers/root/index.test.ts
+++ b/src/handlers/root/index.test.ts
@@ -1,24 +1,14 @@
-import { handler as orig } from '.';
+import * as orig from '.';
 import { mockHandlerFn } from '../../../dev/mockHandlerFn';
 
-const handler = mockHandlerFn(orig);
+const get = mockHandlerFn(orig.get);
+
 describe('Greeting message', () => {
     it('should return well-formed XML', async () => {
-        const result = await handler({
-            pathParameters: { lang: 'fr-FR' },
+        const result = await get({
+            language: 'fr-FR',
+            user: { id: '77-root-test' },
         });
-        expect(result).toMatchObject({
-            statusCode: 200,
-            headers: {
-                'Content-Type': 'text/xml',
-            },
-            body: expect.any(String),
-        });
-        expect(result.body).toMatchSnapshot();
-    });
-
-    it('should gracefully reject unknown languages', async () => {
-        const result = (await handler({}));
-        expect(result.body).toMatchSnapshot();
+        expect(result.toString()).toMatchSnapshot();
     });
 });

--- a/src/handlers/root/index.ts
+++ b/src/handlers/root/index.ts
@@ -1,29 +1,11 @@
 import { twiml } from 'twilio';
-import {
-    getVoiceParams,
-    __,
-    isSupportedLanguage,
-} from '../../services/strings';
+import { getVoiceParams, __ } from '../../services/strings';
 import { safeHandle } from '../../services/errors';
 
-export const handler = safeHandle(async (e) => {
-    // parse input
-    const language = e.pathParameters?.lang;
-    if (!isSupportedLanguage(language)) {
-        throw new Error('Unsupported language');
-    }
-
+export const get = safeHandle(async ({ language }) => {
     // prepare response
     const response = new twiml.VoiceResponse();
     response.say(getVoiceParams(language), __('welcome', language));
     response.redirect({ method: 'GET' }, `./${language}/count`);
-
-    // return answer
-    return {
-        statusCode: 200,
-        headers: {
-            'Content-Type': 'text/xml',
-        },
-        body: response.toString(),
-    };
+    return response;
 });

--- a/src/services/dynamodb.test.ts
+++ b/src/services/dynamodb.test.ts
@@ -1,4 +1,4 @@
-import { getItem, putItem } from './dynamodb';
+import { getItem, putItem, RecordType } from './dynamodb';
 
 describe('dynamodb', () => {
     const OLD_ENV = process.env;
@@ -13,8 +13,11 @@ describe('dynamodb', () => {
     });
 
     test('fetches items correctly', async () => {
-        await expect(getItem('foo')).resolves.toEqual({});
-        await expect(putItem('foo', { count: 12 })).resolves.toEqual({});
+        await expect(getItem('foo')).resolves.toEqual({ id: 'foo' });
+        await expect(putItem({ id: 'foo', count: 12 })).resolves.toEqual({
+            id: 'foo',
+            count: 12,
+        });
         await expect(getItem('foo')).resolves.toEqual({ id: 'foo', count: 12 });
     });
 
@@ -23,8 +26,15 @@ describe('dynamodb', () => {
         await expect(getItem('foo')).rejects.toMatchObject({
             message: expect.stringContaining('Invalid table/index name.'),
         });
-        await expect(putItem('foo', { count: 12 })).rejects.toMatchObject({
+        await expect(putItem({ id: 'foo', count: 12 })).rejects.toMatchObject({
             message: expect.stringContaining('Invalid table/index name.'),
         });
+    });
+
+    test('rejects invalid items', async () => {
+        process.env.TABLE_NAME = undefined;
+        await expect(
+            putItem(({ id: 'foo', count: 'fourteen' } as unknown) as RecordType)
+        ).rejects.toMatchInlineSnapshot(`[Error: Invalid record structure]`);
     });
 });

--- a/src/services/errors.test.ts
+++ b/src/services/errors.test.ts
@@ -1,21 +1,58 @@
 import { safeHandle } from './errors';
-import { mockHandlerFn } from '../../dev/mockHandlerFn';
+import VoiceResponse from 'twilio/lib/twiml/VoiceResponse';
+import qs from 'querystring';
+
+const params = {
+    pathParameters: {
+        lang: 'en-GB',
+    },
+    queryStringParameters: {
+        Caller: '+123456789',
+    },
+};
+
+const postParams = {
+    ...params,
+    body: qs.stringify(params.queryStringParameters),
+    httpMethod: 'POST',
+};
 
 describe('safeHandle', () => {
     test.each`
-        type         | lang         | error                           | message
-        ${'errors'}  | ${'en-GB'}   | ${new Error('Not implemented')} | ${'An error occurred. Not implemented'}
-        ${'errors'}  | ${undefined} | ${new Error('Not implemented')} | ${'An error occurred. Not implemented'}
-        ${'strings'} | ${'fr-FR'}   | ${'something weird'}            | ${"Une erreur s'est produite. something weird"}
-        ${'objects'} | ${'fr-FR'}   | ${{ status: 'bad' }}            | ${"Une erreur s'est produite. "}
-    `('catches $type in $lang', async ({ error, message, lang }) => {
+        case                      | params                                        | statusCode | message
+        ${'undefined parameters'} | ${{}}                                         | ${500}     | ${'An error occurred. Unsupported language'}
+        ${'undefined query'}      | ${{ ...params, queryStringParameters: null }} | ${500}     | ${'An error occurred. Unable to identify caller'}
+        ${'undefined caller'}     | ${{ ...params, queryStringParameters: {} }}   | ${500}     | ${'An error occurred. Unable to identify caller'}
+        ${'happy flow'}           | ${params}                                     | ${200}     | ${'Hello world'}
+        ${'hapy POST flow'}       | ${postParams}                                 | ${200}     | ${'Hello world'}
+    `('handles $case', async ({ message, params, statusCode }) => {
+        const wrapped = safeHandle(async () => {
+            const r = new VoiceResponse();
+            r.say('Hello world');
+            return r;
+        });
+
+        const result = await wrapped(params as never, {} as never, jest.fn);
+        expect(result).toMatchObject({
+            statusCode: statusCode,
+            headers: {
+                'Content-Type': 'text/xml',
+            },
+            body: expect.stringContaining(message),
+        });
+    });
+
+    test.each`
+        type           | error                           | message
+        ${'JS Errors'} | ${new Error('Not implemented')} | ${'An error occurred. Not implemented'}
+        ${'strings'}   | ${'something weird'}            | ${'An error occurred. something weird'}
+        ${'objects'}   | ${{ status: 'bad' }}            | ${'An error occurred. '}
+    `('catches $type', async ({ error, message }) => {
         const wrapped = safeHandle(async () => {
             throw error;
         });
 
-        const result = await mockHandlerFn(wrapped)({
-            pathParameters: lang ? { lang } : undefined,
-        });
+        const result = await wrapped(params as never, {} as never, jest.fn);
         expect(result).toMatchObject({
             statusCode: 500,
             headers: {

--- a/src/services/errors.ts
+++ b/src/services/errors.ts
@@ -1,33 +1,82 @@
+import { APIGatewayProxyHandler, APIGatewayProxyEvent } from 'aws-lambda';
 import {
-    APIGatewayProxyHandler,
-    APIGatewayProxyEvent,
-    APIGatewayProxyResult,
-} from 'aws-lambda';
-import { getVoiceParams, __, isSupportedLanguage } from './strings';
+    getVoiceParams,
+    __,
+    isSupportedLanguage,
+    SupportedLanguage,
+} from './strings';
 import { twiml } from 'twilio';
+import VoiceResponse from 'twilio/lib/twiml/VoiceResponse';
+import { getItem, RecordType } from './dynamodb';
+import qs from 'querystring';
+
+export interface ParsedRequest {
+    language: SupportedLanguage;
+    user: RecordType;
+    event: APIGatewayProxyEvent;
+}
+
+async function parseRequest(
+    event: APIGatewayProxyEvent
+): Promise<ParsedRequest> {
+    const language = event.pathParameters?.lang;
+    if (!isSupportedLanguage(language)) {
+        throw new Error('Unsupported language');
+    }
+    const body = qs.parse(event.body || '');
+    const Caller = body.Caller || event.queryStringParameters?.Caller;
+    if (typeof Caller !== 'string' || Caller.length < 3) {
+        throw new Error('Unable to identify caller');
+    }
+    const user = await getItem(Caller);
+    return {
+        language,
+        user,
+        event,
+    };
+}
 
 export const safeHandle = (
-    f: (e: APIGatewayProxyEvent) => Promise<APIGatewayProxyResult>
-): APIGatewayProxyHandler => (e) =>
-    f(e).catch((err) => {
-        const maybeLang = e.pathParameters?.lang;
-        const language = isSupportedLanguage(maybeLang) ? maybeLang : 'en-GB';
-        const response = new twiml.VoiceResponse();
-        const message =
-            typeof err === 'string'
-                ? err
-                : typeof err.message === 'string'
-                ? err.message
-                : '';
-        response.say(
-            getVoiceParams(language),
-            __('error', { message }, language)
-        );
-        return {
-            statusCode: 500,
-            headers: {
-                'Content-Type': 'text/xml',
-            },
-            body: response.toString(),
-        };
-    });
+    f: (e: ParsedRequest) => Promise<VoiceResponse>
+): APIGatewayProxyHandler => {
+    const safeHandler = async function safelyHandledFunction(
+        e: APIGatewayProxyEvent
+    ) {
+        try {
+            const result = await parseRequest(e);
+            const response = await f(result);
+            return {
+                statusCode: 200,
+                headers: {
+                    'Content-Type': 'text/xml',
+                },
+                body: response.toString(),
+            };
+        } catch (err) {
+            const maybeLang = e.pathParameters?.lang;
+            const language = isSupportedLanguage(maybeLang)
+                ? maybeLang
+                : 'en-GB';
+            const response_1 = new twiml.VoiceResponse();
+            const message =
+                typeof err === 'string'
+                    ? err
+                    : typeof err.message === 'string'
+                    ? err.message
+                    : '';
+            response_1.say(
+                getVoiceParams(language),
+                __('error', { message }, language)
+            );
+            return {
+                statusCode: 500,
+                headers: {
+                    'Content-Type': 'text/xml',
+                },
+                body: response_1.toString(),
+            };
+        }
+    };
+    safeHandler.orig = f;
+    return safeHandler;
+};

--- a/src/services/strings.test.ts
+++ b/src/services/strings.test.ts
@@ -1,4 +1,4 @@
-import { isSupportedLanguage, __ } from './strings';
+import { isSupportedLanguage, __, getVoiceParams } from './strings';
 
 describe('isSupportedLangage', () => {
     it.each`
@@ -14,11 +14,22 @@ describe('isSupportedLangage', () => {
     );
 });
 
+describe('voiceParams', () => {
+    test.each`
+        language     | voice
+        ${undefined} | ${'Polly.Amy'}
+        ${'fr-FR'}   | ${'Polly.Celine'}
+        ${'en-GB'}   | ${'Polly.Amy'}
+    `('picks the right voice for $lang', async ({ language, voice }) => {
+        expect(getVoiceParams(language)).toEqual({ language, voice });
+    });
+});
+
 describe('i18n', () => {
     test('translates without data', () => {
-        expect(__('welcome', 'en-GB')).toEqual('Hello there!');
-        expect(__('welcome', 'fr-FR')).toEqual('Bonjour!');
-        expect(__('welcome', 'pt-BR')).toEqual('Hello there!');
+        expect(__('test', 'en-GB')).toEqual('Hello there!');
+        expect(__('test', 'fr-FR')).toEqual('Bonjour!');
+        expect(__('test', 'pt-BR')).toEqual('Hello there!');
     });
 
     test.each`

--- a/src/services/strings.ts
+++ b/src/services/strings.ts
@@ -7,7 +7,7 @@ formatMessage.setup({
     missingTranslation: 'error', // don't console.warn or throw an error when a translation is missing
 });
 
-type SupportedLanguage = 'en-GB' | 'fr-FR';
+export type SupportedLanguage = 'en-GB' | 'fr-FR';
 
 export function isSupportedLanguage(
     language: unknown
@@ -20,6 +20,7 @@ export function getVoiceParams(language: SupportedLanguage): SayAttributes {
     // voice list: https://docs.aws.amazon.com/polly/latest/dg/voicelist.html
     switch (language) {
         case 'en-GB':
+        default:
             return {
                 language,
                 voice: 'Polly.Amy',

--- a/src/strings/en-GB.json
+++ b/src/strings/en-GB.json
@@ -1,4 +1,5 @@
 {
+    "test": "Hello there!",
     "welcome": "Hello there!",
     "caller-count": "This is the {count, selectordinal, one{#st} two{#nd} few{#rd} other{#th}} time you've called.",
     "recording-request": "Please record your message, then press the hash key.",

--- a/src/strings/fr-FR.json
+++ b/src/strings/fr-FR.json
@@ -1,4 +1,5 @@
 {
+    "test": "Bonjour!",
     "welcome": "Bonjour!",
     "caller-count": "C'est la {count, selectordinal, one{première} other{#ème}} fois que vous appelez.",
     "recording-request": "Veuillez enregistrer votre message, puis appuyez sur la touche dièse.",

--- a/template.yaml
+++ b/template.yaml
@@ -7,6 +7,9 @@ Globals:
     Runtime: nodejs12.x
     Timeout: 180
     Tracing: Active
+    Environment:
+      Variables:
+        TABLE_NAME: !Ref AccountsTable
 
 Resources:
   ApiGatewayApi:
@@ -14,63 +17,65 @@ Resources:
     Properties:
       StageName: dev
 
-  GreetingFunction:
+  RootWelcome:
     Type: AWS::Serverless::Function
     Properties:
+      Handler: index.get
+      CodeUri: ./dist/handlers/root
+      Role: !GetAtt LambdaRole.Arn
       Events:
-        HTTPGet:
+        HTTP:
           Type: Api
           Properties:
             Path: /{lang}
             Method: GET
             RestApiId:
               Ref: ApiGatewayApi
-      Handler: index.handler
-      CodeUri: ./dist/handlers/root
-      Role: !GetAtt LambdaRole.Arn
 
   CallerCountFunction:
     Type: AWS::Serverless::Function
     Properties:
+      Handler: index.get
+      CodeUri: ./dist/handlers/callerCount
+      Role: !GetAtt LambdaRole.Arn
       Events:
-        HTTPGet:
+        HTTP:
           Type: Api
           Properties:
             Path: /{lang}/count
             Method: GET
             RestApiId:
               Ref: ApiGatewayApi
-      Handler: index.handler
-      CodeUri: ./dist/handlers/callerCount
-      Environment:
-        Variables:
-          TABLE_NAME: !Ref AccountsTable
-      Role: !GetAtt LambdaRole.Arn
 
-  RecordMessageFunction:
+  RecordMessageWelcome:
     Type: AWS::Serverless::Function
     Properties:
+      Handler: index.get
+      CodeUri: ./dist/handlers/record
+      Role: !GetAtt LambdaRole.Arn
       Events:
-        HTTPGet:
+        HTTP:
           Type: Api
           Properties:
             Path: /{lang}/record
             Method: GET
             RestApiId:
               Ref: ApiGatewayApi
-        HTTPPost:
+
+  RecordMessageFunction:
+    Type: AWS::Serverless::Function
+    Properties:
+      Handler: index.post
+      CodeUri: ./dist/handlers/record
+      Role: !GetAtt LambdaRole.Arn
+      Events:
+        HTTP:
           Type: Api
           Properties:
             Path: /{lang}/record
             Method: POST
             RestApiId:
               Ref: ApiGatewayApi
-      Handler: index.handler
-      CodeUri: ./dist/handlers/record
-      Environment:
-        Variables:
-          TABLE_NAME: !Ref AccountsTable
-      Role: !GetAtt LambdaRole.Arn
 
   AccountsTable:
     Type: AWS::DynamoDB::Table


### PR DESCRIPTION
This PR adds logic to the "safeHandle" method to centralise parsing incoming requests and constructing return XML. This makes the handlers simpler and easier to test, so there's quite a lot of files touched as tests are updated across the codebase.