### PR TITLE
Use language en-DEV in tests for stable snapshot

### DIFF
--- a/src/handlers/callerCount/__snapshots__/index.test.ts.snap
+++ b/src/handlers/callerCount/__snapshots__/index.test.ts.snap
@@ -13,7 +13,7 @@ exports[`Caller count should return well-formed XML 1`] = `
 <?xml version="1.0" encoding="UTF-8"?>
 <Response>
     <Say language="en-GB" voice="Polly.Emma-Neural">
-        Thanks for calling. This was the 1st time you've called.
+        caller-count
     </Say>
 </Response>
 `;

--- a/src/handlers/callerCount/index.test.ts
+++ b/src/handlers/callerCount/index.test.ts
@@ -6,7 +6,7 @@ const get = mockHandlerFn(orig.get);
 describe('Caller count', () => {
     it('should return well-formed XML', async () => {
         const result = await get({
-            language: 'en-GB',
+            language: 'en-DEV',
             user: { id: '+77-caller-test' },
         });
         expect(result.toString()).toMatchSnapshot();

--- a/src/handlers/root/__snapshots__/index.test.ts.snap
+++ b/src/handlers/root/__snapshots__/index.test.ts.snap
@@ -5,11 +5,11 @@ exports[`Greeting message should greet enrolled users 1`] = `
 <Response>
     <Gather input="dtmf speech" method="POST" language="en-GB" hints="record,sign up,enrol,one,1,hear,listen,two,2" speechTimeout="auto" numDigits="1" timeout="5" speechModel="default">
         <Say language="en-GB" voice="Polly.Emma-Neural">
-            Hello again. Please say the name of the service you're looking for, or listen to the options available. If you would like to record a message, press 1. If you'd like to hear your recorded message, press 2. Otherwise, please hold.
+            welcome-known
         </Say>
     </Gather>
     <Redirect method="GET">
-        ./en-GB/count
+        ./en-DEV/count
     </Redirect>
 </Response>
 `;
@@ -19,11 +19,11 @@ exports[`Greeting message should greet strangers 1`] = `
 <Response>
     <Gather input="dtmf speech" method="POST" language="en-GB" hints="record,sign up,enrol,one,1,hear,listen,two,2" speechTimeout="auto" numDigits="1" timeout="5" speechModel="default">
         <Say language="en-GB" voice="Polly.Emma-Neural">
-            Hello. It looks like you're not yet signed up. Press 1 to do so, or say "sign up". Otherwise, please hold.
+            welcome-stranger
         </Say>
     </Gather>
     <Redirect method="GET">
-        ./en-GB/count
+        ./en-DEV/count
     </Redirect>
 </Response>
 `;

--- a/src/handlers/root/index.test.ts
+++ b/src/handlers/root/index.test.ts
@@ -7,14 +7,15 @@ const post = mockHandlerFn(orig.post);
 
 describe('Greeting message', () => {
     test.each`
-        type                | user
-        ${'strangers'}      | ${{}}
-        ${'enrolled users'} | ${{ recordingUrl: 'hello.wav' }}
-    `('should greet $type', async ({ user }) => {
+        type                | user                             | message
+        ${'strangers'}      | ${{}}                            | ${'welcome-stranger'}
+        ${'enrolled users'} | ${{ recordingUrl: 'hello.wav' }} | ${'welcome-known'}
+    `('should greet $type', async ({ user, message }) => {
         const result = await get({
-            language: 'en-GB',
+            language: 'en-DEV',
             user: { id: '+77-root-test', ...user },
         });
+        expect(result.toString()).toContain(message);
         expect(result.toString()).toMatchSnapshot();
     });
 

--- a/src/handlers/root/index.ts
+++ b/src/handlers/root/index.ts
@@ -30,10 +30,11 @@ export const post = safeHandle(async ({ language, user, event }) => {
 
 export const get = safeHandle(async ({ language, user }) => {
     const response = new twiml.VoiceResponse();
+    const voice = getVoiceParams(language);
     const gather = response.gather({
         input: ['dtmf', 'speech'],
         method: 'POST',
-        language,
+        language: voice.language,
         hints: recordOptions.concat(listenOptions).join(','),
         speechTimeout: 'auto',
         numDigits: 1,
@@ -41,9 +42,9 @@ export const get = safeHandle(async ({ language, user }) => {
         speechModel: 'default',
     });
     if (user && user.recordingUrl) {
-        gather.say(getVoiceParams(language), __('welcome-known', language));
+        gather.say(voice, __('welcome-known', language));
     } else {
-        gather.say(getVoiceParams(language), __('welcome-stranger', language));
+        gather.say(voice, __('welcome-stranger', language));
     }
 
     // if the gather doesn't detect anything, we fall back on this next instruction:

--- a/src/services/strings.test.ts
+++ b/src/services/strings.test.ts
@@ -16,13 +16,20 @@ describe('isSupportedLangage', () => {
 
 describe('voiceParams', () => {
     test.each`
-        language     | voice
-        ${undefined} | ${'Polly.Emma-Neural'}
-        ${'fr-FR'}   | ${'Polly.Celine'}
-        ${'en-GB'}   | ${'Polly.Emma-Neural'}
-    `('picks the right voice for $lang', async ({ language, voice }) => {
-        expect(getVoiceParams(language)).toEqual({ language, voice });
-    });
+        language     | expected   | voice
+        ${undefined} | ${'en-GB'} | ${'Polly.Emma-Neural'}
+        ${'en-DEV'}  | ${'en-GB'} | ${'Polly.Emma-Neural'}
+        ${'fr-FR'}   | ${'fr-FR'} | ${'Polly.Celine'}
+        ${'en-GB'}   | ${'en-GB'} | ${'Polly.Emma-Neural'}
+    `(
+        'picks the right voice for $language',
+        async ({ language, voice, expected }) => {
+            expect(getVoiceParams(language)).toEqual({
+                language: expected,
+                voice,
+            });
+        }
+    );
 });
 
 describe('i18n', () => {

--- a/src/services/strings.ts
+++ b/src/services/strings.ts
@@ -1,4 +1,9 @@
-import { SayAttributes } from 'twilio/lib/twiml/VoiceResponse';
+import {
+    SayAttributes,
+    SayLanguage,
+    GatherLanguage,
+    SayVoice,
+} from 'twilio/lib/twiml/VoiceResponse';
 import { translations, MessageId } from '../strings';
 import formatMessage from 'format-message';
 
@@ -7,22 +12,29 @@ formatMessage.setup({
     missingTranslation: 'error', // don't console.warn or throw an error when a translation is missing
 });
 
-export type SupportedLanguage = 'en-GB' | 'fr-FR';
+const supportedLanguages = [
+    'en-GB' as const,
+    'fr-FR' as const,
+    'en-DEV' as const,
+];
+export type SupportedLanguage = typeof supportedLanguages[0];
 
 export function isSupportedLanguage(
     language: unknown
 ): language is SupportedLanguage {
-    if (typeof language !== 'string') return false;
-    return ['en-GB', 'fr-FR'].indexOf(language) >= 0;
+    return supportedLanguages.some((l) => l === language);
 }
 
-export function getVoiceParams(language: SupportedLanguage): SayAttributes {
+export function getVoiceParams(
+    language: SupportedLanguage
+): { language: SayLanguage & GatherLanguage; voice: SayVoice } {
     // voice list: https://docs.aws.amazon.com/polly/latest/dg/voicelist.html
     switch (language) {
         case 'en-GB':
+        case 'en-DEV':
         default:
             return {
-                language,
+                language: 'en-GB',
                 voice: 'Polly.Emma-Neural',
             };
         case 'fr-FR':

--- a/src/services/voiceit.ts
+++ b/src/services/voiceit.ts
@@ -12,6 +12,12 @@ export const AVAILABLE_VOICEPRINTS = {
         Zoo: 'Zoos are filled with small and large animals',
         Telecom: 'please log in to my telecom services account',
     },
+    'en-DEV': {
+        // These will get mocked anyway so we can use whatever
+        Tomorrow: 'Never forget tomorrow is a new day',
+        Zoo: 'Zoos are filled with small and large animals',
+        Telecom: 'please log in to my telecom services account',
+    },
     'fr-FR': {
         //  TODO: add voiceprints after they are set up in VoiceIt
     },

--- a/src/strings/en-DEV.json
+++ b/src/strings/en-DEV.json
@@ -1,0 +1,17 @@
+{
+    "test": "test",
+    "record-message-prompt": "record-message-prompt",
+    "hear-message-prompt": "hear-message-prompt",
+    "call-count-prompt": "call-count-prompt",
+    "mobile-money-prompt": "mobile-money-prompt",
+    "bill-prompt": "bill-prompt",
+    "account-prompt": "account-prompt",
+    "not-implemented": "not-implemented",
+    "welcome-stranger": "welcome-stranger",
+    "welcome-known": "welcome-known",
+    "did-not-understand": "did-not-understand",
+    "caller-count": "caller-count",
+    "recording-request": "recording-request",
+    "recording-confirmation": "recording-confirmation",
+    "error": "error"
+}

--- a/src/strings/index.ts
+++ b/src/strings/index.ts
@@ -1,9 +1,15 @@
+import dev from './en-DEV.json';
 import en from './en-GB.json';
 import fr from './fr-FR.json';
+import { SupportedLanguage } from '../services/strings';
 
-export type MessageId = keyof typeof en;
+export type MessageId = keyof typeof en & keyof typeof fr & keyof typeof dev;
 
-export const translations: Record<string, Record<MessageId, string>> = {
+export const translations: Record<
+    SupportedLanguage,
+    Record<MessageId, string>
+> = {
+    'en-DEV': dev,
     'en-GB': en,
     'fr-FR': fr,
 };

--- a/src/types/voiceit.d.ts
+++ b/src/types/voiceit.d.ts
@@ -287,7 +287,10 @@ declare module 'voiceit2-nodejs' {
             // Zulu (South Africa)
             | 'zu-ZA';
 
-        export type ContentLanguage = BasicLanguage | PremiumLanguage;
+        export type ContentLanguage =
+            | BasicLanguage
+            | PremiumLanguage
+            | 'en-DEV';
 
         export type Response<T> = T & {
             message: string;


### PR DESCRIPTION
In tests we will check for a particular message being read to the user. Using "Hello!" is unstable because we might one day decide to change the greeting to "Ahoy!" or other. If we do that, our tests will fail even though we didn't change any business logic.

In this PR I add a third language `en-DEV`, for which the strings should not normally be changed after initial creation. This ensures that we can change the language strings in future without causing test failures.